### PR TITLE
Add sci logo to sci playground app

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -2,6 +2,11 @@
 
 #sci {
   margin: 2em;
+  background-image: url("https://raw.githubusercontent.com/borkdude/sci/master/logo/icon.png");
+  background-position: right 10px top;
+  background-repeat: no-repeat;
+  background-size: 90px 90px;
+  position: relative;
 }
 
 /* footer always at bottom */


### PR DESCRIPTION
Logo is referenced from as raw github content from:
https://github.com/borkdude/sci/blob/master/logo/icon.png